### PR TITLE
[woff2_dec] fix test for UintBase128 overflow

### DIFF
--- a/woff2/woff2_dec.cc
+++ b/woff2/woff2_dec.cc
@@ -107,7 +107,7 @@ bool ReadBase128(Buffer* buf, uint32_t* value) {
       return FONT_COMPRESSION_FAILURE();
     }
     // If any of the top seven bits are set then we're about to overflow.
-    if (result & 0xe000000) {
+    if (result & 0xfe000000) {
       return FONT_COMPRESSION_FAILURE();
     }
     result = (result << 7) | (code & 0x7f);


### PR DESCRIPTION
Hello,

I believe there is an involuntary typo in the "woff2_dec.cc" (line 110), inside `ReadBase128`, where it tests if the UintBase128-encoded value is about to overflow.
If I understand this correctly, the purpose of this check is to avoid that the resulting value exceeds 2**32-1.
Is that correct?

All best,

Cosimo
