### PR TITLE
[normalize.cc] set bit 11 of head table flags for lossless transform

### DIFF
--- a/src/normalize.cc
+++ b/src/normalize.cc
@@ -252,11 +252,26 @@ bool FixChecksums(Font* font) {
   return true;
 }
 
+bool SetHeadTransformFlag(Font* font) {
+  Font::Table* head_table = font->FindTable(kHeadTableTag);
+  if (head_table->reuse_of != NULL) {
+    head_table = head_table->reuse_of;
+  }
+  if (head_table == NULL || head_table->length < 18) {
+    return FONT_COMPRESSION_FAILURE();
+  }
+  // set bit 11 of head table 'flags' to indicate lossless modifying transform
+  int head_flags = head_table->data[16];
+  head_table->buffer[16] = head_flags | (1 << 3);
+  return true;
+}
+
 bool NormalizeWithoutFixingChecksums(Font* font) {
   return (MakeEditableBuffer(font, kHeadTableTag) &&
           RemoveDigitalSignature(font) &&
           NormalizeGlyphs(font) &&
-          NormalizeOffsets(font));
+          NormalizeOffsets(font) &&
+          SetHeadTransformFlag(font));
 }
 
 bool NormalizeFont(Font* font) {


### PR DESCRIPTION
cc @rsheeter

http://dev.w3.org/webfonts/WOFF2/spec/

> The WOFF 2.0 encoders MUST also set bit 11 of the 'flags' field of the head table (see [OFF] specification) to indicate that a recreated font file was subjected to lossless modifying transform.