### PR TITLE
decoder should only reorder the table directory

### DIFF
--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -934,6 +934,7 @@ bool ConvertWOFF2ToTTF(uint8_t* result, size_t result_length,
   }
 
   // Re-order tables in output (OTSpec) order
+  std::vector<Table> sorted_tables(tables);
   if (header_version) {
     // collection; we have to sort the table offset vector in each font
     for (auto& ttc_font : ttc_fonts) {
@@ -948,7 +949,7 @@ bool ConvertWOFF2ToTTF(uint8_t* result, size_t result_length,
     }
   } else {
     // non-collection; we can just sort the tables
-    std::sort(tables.begin(), tables.end());
+    std::sort(sorted_tables.begin(), sorted_tables.end());
   }
 
   // Start building the font
@@ -989,7 +990,7 @@ bool ConvertWOFF2ToTTF(uint8_t* result, size_t result_length,
   } else {
     offset = StoreOffsetTable(result, offset, flavor, num_tables);
     for (uint16_t i = 0; i < num_tables; ++i) {
-      offset = StoreTableEntry(result, tables[i], offset);
+      offset = StoreTableEntry(result, sorted_tables[i], offset);
     }
   }
 
@@ -1070,7 +1071,7 @@ bool ConvertWOFF2ToTTF(uint8_t* result, size_t result_length,
       return FONT_COMPRESSION_FAILURE();
     }
   } else {
-    if (!FixChecksums(tables, result)) {
+    if (!FixChecksums(sorted_tables, result)) {
       return FONT_COMPRESSION_FAILURE();
     }
   }


### PR DESCRIPTION
The decoder fails to decompress a WOFF2 font when the tables are not ordered alphabetically. The issue passed undetected because the google/woff2 encoder (unnecessarily) does the reordering when creating the WOFF2 font. However, if a valid WOFF2 font is created using a different authoring tool (one which keeps the WOFF2 directory according to the 'physical order', i.e. in the same order as the tables were encoded in the compressed Brotli stream), then the google/woff2 decoder fails.

When the decoder reads the table entries into the 'tables' vector, it also sets a `kWoff2FlagsContinueStream` flag that is used in a subsequent for loop to decide whether to decompress the Brotli stream or continue.

The problem occurs when this same 'tables' vector is then reordered alphabetically, thus modifying the logic of the above mentioned flags, and making the decompression fail.

Instead of reordering the vector in place, one should create a sorted copy of 'tables' vector, and use the latter when storing the table directory entries (or when fixing the checksums). On the other hand, the original 'tables' vector, i.e. the one which mirrors the table order from the input font, should be used when decompressing and storing the table data to the output font.

In this way, the output SFNT font will have a table directory sorted alphabetically as per OT spec, with the table data located at the offsets specified in the table directory (not necessarily in the same ascending order).