### PR TITLE
Makefile fixes and cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,20 @@
 OS := $(shell uname)
 
-IDIRS=-I./brotli/dec/ -I./brotli/enc/ -I./src
+CPPFLAGS = -I./brotli/dec/ -I./brotli/enc/ -I./src
 
-CXX = g++
-LFLAGS =
-GFLAGS=-no-canonical-prefixes -fno-omit-frame-pointer -m64
-CXXFLAGS = -c $(IDIRS) -std=c++0x $(GFLAGS)
+CC ?= gcc
+CXX ?= g++
+
+COMMON_FLAGS = -fno-omit-frame-pointer -no-canonical-prefixes
 
 ifeq ($(OS), Darwin)
-  CXXFLAGS += -DOS_MACOSX
+  CPPFLAGS += -DOS_MACOSX
 else
-  CXXFLAGS += -fno-tree-vrp
+  COMMON_FLAGS += -fno-tree-vrp
 endif
+
+CFLAGS += $(COMMON_FLAGS)
+CXXFLAGS += $(COMMON_FLAGS) -std=c++11
 
 SRCDIR = src
 
@@ -33,10 +36,10 @@ $(EXECUTABLES) : $(EXE_OBJS) deps
 	$(CXX) $(LFLAGS) $(OBJS) $(ENCOBJ) $(DECOBJ) $(SRCDIR)/$@.o -o $@
 
 deps :
-	make -C $(BROTLI)/dec
-	make -C $(BROTLI)/enc
+	$(MAKE) -C $(BROTLI)/dec
+	$(MAKE) -C $(BROTLI)/enc
 
 clean :
 	rm -f $(OBJS) $(EXE_OBJS) $(EXECUTABLES)
-	make -C $(BROTLI)/dec clean
-	make -C $(BROTLI)/enc clean
+	$(MAKE) -C $(BROTLI)/dec clean
+	$(MAKE) -C $(BROTLI)/enc clean


### PR DESCRIPTION
- Distinguish between CC/CFLAGS, CPP/CPPFLAGS and CXX/CXXFLAGS.
  Do not store compiler flags in CPPFLAGS, which is for preprocessor.
- Use COMMON_FLAGS for flags that are for both C and C++.
- Use $(MAKE) instead of make, so that parallel building works.
- Drop -m64 flag which is wrong on 32-bit systems.

This also needs google/brotli#35.