### PR TITLE
Fix decode error

### DIFF
--- a/src/round.h
+++ b/src/round.h
@@ -30,6 +30,13 @@ template<typename T> T Round4(T value) {
   return (value + 3) & ~3;
 }
 
+template<typename T> T Round2(T value) {
+  if (value == std::numeric_limits<T>::max()) {
+    return value;
+  }
+  return (value + 1) & ~1;
+}
+
 } // namespace woff2
 
 #endif  // WOFF2_ROUND_H_

--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -516,7 +516,7 @@ bool ReconstructGlyf(const uint8_t* data, size_t data_size,
     if (glyph_size + 3 < glyph_size) {
       return FONT_COMPRESSION_FAILURE();
     }
-    glyph_size = Round4(glyph_size);
+    glyph_size = Round2(glyph_size);
     if (glyph_size > dst_size - loca_offset) {
       // This shouldn't happen, but this test defensively maintains the
       // invariant that loca_offset <= dst_size.


### PR DESCRIPTION
This is backported from OTS, it fixes decoding the `tabledata-valid-loca-001.woff2` font from the WOFF2 test suite.