### PR TITLE
Allow to use CLI utils with stdin/stdout

### DIFF
--- a/src/woff2_compress.cc
+++ b/src/woff2_compress.cc
@@ -23,14 +23,21 @@
 int main(int argc, char **argv) {
   using std::string;
 
-  if (argc != 2) {
-    fprintf(stderr, "One argument, the input filename, must be provided.\n");
+  if (argc < 2) {
+    fprintf(stderr, "At least one argument, the input filename, must be provided.\n");
+    return 1;
+  }
+
+  if (argc > 3) {
+    fprintf(stderr, "A maximum of two arguments, can be provided, the input filename and the output one.\n");
     return 1;
   }
 
   string filename(argv[1]);
-  string outfilename = filename.substr(0, filename.find_last_of(".")) + ".woff2";
-  fprintf(stdout, "Processing %s => %s\n",
+  string outfilename =  argc == 2 ?
+    filename.substr(0, filename.find_last_of(".")) + ".woff2" :
+    argv[2];
+  argc == 2 && fprintf(stdout, "Processing %s => %s\n",
     filename.c_str(), outfilename.c_str());
   string input = woff2::GetFileContent(filename);
 

--- a/src/woff2_decompress.cc
+++ b/src/woff2_decompress.cc
@@ -24,14 +24,21 @@
 int main(int argc, char **argv) {
   using std::string;
 
-  if (argc != 2) {
-    fprintf(stderr, "One argument, the input filename, must be provided.\n");
+  if (argc < 2) {
+    fprintf(stderr, "At least one argument, the input filename, must be provided.\n");
+    return 1;
+  }
+
+  if (argc > 3) {
+    fprintf(stderr, "A maximum of two arguments, can be provided, the input filename and the output one.\n");
     return 1;
   }
 
   string filename(argv[1]);
-  string outfilename = filename.substr(0, filename.find_last_of(".")) + ".ttf";
-  fprintf(stdout, "Processing %s => %s\n",
+  string outfilename =  argc == 2 ?
+    filename.substr(0, filename.find_last_of(".")) + ".ttf" :
+    argv[2];
+  argc == 2 && fprintf(stdout, "Processing %s => %s\n",
     filename.c_str(), outfilename.c_str());
   string input = woff2::GetFileContent(filename);
 


### PR DESCRIPTION
I had to fork the project in order to support WOFF2 files for the [gulp-iconfont](https://github.com/nfroidure/gulp-iconfont) project.

Indeed, it was not possible to get font data from stdin and to output it to stdout.

This changes includes an operational second argument to specify the output path. That way, you can do:
```sh
woff2_compress /dev/stdin /dev/stdout
```
like i did here https://github.com/nfroidure/gulp-iconfont/blob/master/src/index.js#L65

Also, i had to mute the prints if a second argument is provided in order to not corrupt the font when outputting to stdout. Chances are it is not that useful when you provide the output file.

I'm not a C++ developer and you may want to do this another way but please at least consider making stdin/stdout usable.