### PR TITLE
Kill kWoff2FlagsContinueStream

### DIFF
--- a/src/woff2_common.h
+++ b/src/woff2_common.h
@@ -26,7 +26,6 @@ namespace woff2 {
 
 static const uint32_t kWoff2Signature = 0x774f4632;  // "wOF2"
 
-const unsigned int kWoff2FlagsContinueStream = 1 << 4;
 const unsigned int kWoff2FlagsTransform = 1 << 5;
 
 // TrueType Collection ID string: 'ttcf'

--- a/src/woff2_enc.cc
+++ b/src/woff2_enc.cc
@@ -340,7 +340,6 @@ bool ConvertTTFToWOFF2(const uint8_t *data, size_t length,
       } else {
         table.dst_length = 0;
         table.dst_data = NULL;
-        table.flags |= kWoff2FlagsContinueStream;
       }
       tables.push_back(table);
     }


### PR DESCRIPTION
There is only a single data stream for all the compressed tables, but
the code was originally written for separately compressed tables then
retrofitted, so this is an attempt to streamline it a bit.