### PR TITLE
Expose Brotli quality parameter

### DIFF
--- a/src/woff2_enc.h
+++ b/src/woff2_enc.h
@@ -41,6 +41,9 @@ bool ConvertTTFToWOFF2(const uint8_t *data, size_t length,
                        uint8_t *result, size_t *result_length,
                        const string& extended_metadata);
 
+bool ConvertTTFToWOFF2(const uint8_t *data, size_t length,
+                       uint8_t *result, size_t *result_length,
+                       int quality, const string& extended_metadata);
 } // namespace woff2
 
 #endif  // WOFF2_WOFF2_ENC_H_


### PR DESCRIPTION
This adds the Brotli quality parameter (for controlling speed/compression) to the `ConvertTTFToWOFF2` method. The existing `ConvertTTFToWOFF2` method signature is preserved so any library depending on the method signature will continue to compile (and use the default quality settings). At Typekit we use this to generate WOFF2 files on the fly (where the default quality settings are to slow to be usable).

If there is interest, I can do another pull request that adds this as a command line option.