### PR TITLE
Don’t print to stderr unless a standalone binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CPPFLAGS = -I./brotli/dec/ -I./brotli/enc/ -I./src
 CC ?= gcc
 CXX ?= g++
 
-COMMON_FLAGS = -fno-omit-frame-pointer -no-canonical-prefixes
+COMMON_FLAGS = -fno-omit-frame-pointer -no-canonical-prefixes -DFONT_COMPRESSION_BIN
 
 ifeq ($(OS), Darwin)
   CPPFLAGS += -DOS_MACOSX

--- a/src/normalize.cc
+++ b/src/normalize.cc
@@ -286,8 +286,10 @@ bool NormalizeFontCollection(FontCollection* font_collection) {
     font_collection->fonts.size());
   for (auto& font : font_collection->fonts) {
     if (!NormalizeWithoutFixingChecksums(&font)) {
+#ifdef FONT_COMPRESSION_BIN
       fprintf(stderr, "Font normalization failed.\n");
-      return false;
+#endif
+      return FONT_COMPRESSION_FAILURE();
     }
     offset += kSfntHeaderSize + kSfntEntrySize * font.num_tables;
   }
@@ -308,8 +310,10 @@ bool NormalizeFontCollection(FontCollection* font_collection) {
   // Now we can fix the checksums
   for (auto& font : font_collection->fonts) {
     if (!FixChecksums(&font)) {
+#ifdef FONT_COMPRESSION_BIN
       fprintf(stderr, "Failed to fix checksums\n");
-      return false;
+#endif
+      return FONT_COMPRESSION_FAILURE();
     }
   }
 

--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -901,7 +901,9 @@ bool ConvertWOFF2ToTTF(uint8_t* result, size_t result_length,
       }
 
       if (PREDICT_FALSE((glyf_table == NULL) != (loca_table == NULL))) {
+#ifdef FONT_COMPRESSION_BIN
         fprintf(stderr, "Cannot have just one of glyf/loca\n");
+#endif
         return FONT_COMPRESSION_FAILURE();
       }
 
@@ -936,9 +938,11 @@ bool ConvertWOFF2ToTTF(uint8_t* result, size_t result_length,
     dst_offset = Round4(dst_offset);
   }
   if (PREDICT_FALSE(src_offset > length || dst_offset != result_length)) {
+#ifdef FONT_COMPRESSION_BIN
     fprintf(stderr, "offset fail; src_offset %" PRIu64 " length %lu "
       "dst_offset %" PRIu64 " result_length %lu\n",
       src_offset, length, dst_offset, result_length);
+#endif
     return FONT_COMPRESSION_FAILURE();
   }
 


### PR DESCRIPTION
We will use woff2 code from OTS and it is undesirable for a library to
print messages to stderr.

I added a macro `FONT_COMPRESSION_BIN` to enable those messages only when building as standalone tool, but it can be tided to `FONT_COMPRESSION_DEBUG` instead if this is more desirable.