### PR TITLE
[woff2_dec] fix issue with PRIu64 on MinGW32

### DIFF
--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -14,6 +14,9 @@
 //
 // Library for converting WOFF2 format font files to their TTF versions.
 
+#define __STDC_FORMAT_MACROS 1
+#include <inttypes.h>
+
 #include "./woff2_dec.h"
 
 #include <stdlib.h>


### PR DESCRIPTION
When I try to `make` the executables using gcc 5.2.0 on MinGW32 (Windows), I get this error:
```
src/woff2_dec.cc:939:49: error: expected ')' before 'PRIu64'
     fprintf(stderr, "offset fail; src_offset %" PRIu64 " length %lu "
                                                 ^
<builtin>: recipe for target 'src/woff2_dec.o' failed
make: *** [src/woff2_dec.o] Error 1
```
It seems like for C++, the `PRIu64` format specifier is only defined when `__STDC_FORMAT_MACROS 1` is defined and `inttypes.h` are included.

I'm not sure this is the right fix in general, but at least it worked for me.