### PR TITLE
Add -Wsign-compare compile flag, fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CPPFLAGS = -I./brotli/dec/ -I./brotli/enc/ -I./src
 CC ?= gcc
 CXX ?= g++
 
-COMMON_FLAGS = -fno-omit-frame-pointer -no-canonical-prefixes -DFONT_COMPRESSION_BIN -D __STDC_FORMAT_MACROS
+COMMON_FLAGS = -fno-omit-frame-pointer -no-canonical-prefixes -DFONT_COMPRESSION_BIN -D __STDC_FORMAT_MACROS -Wsign-compare
 
 ifeq ($(OS), Darwin)
   CPPFLAGS += -DOS_MACOSX

--- a/src/font.cc
+++ b/src/font.cc
@@ -145,7 +145,7 @@ bool ReadTrueTypeCollection(Buffer* file, const uint8_t* data, size_t len,
     }
 
     std::vector<uint32_t> offsets;
-    for (auto i = 0; i < num_fonts; i++) {
+    for (uint32_t i = 0; i < num_fonts; i++) {
       uint32_t offset;
       if (!file->ReadU32(&offset)) {
         return FONT_COMPRESSION_FAILURE();
@@ -301,7 +301,7 @@ bool WriteFontCollection(const FontCollection& font_collection, uint8_t* dst,
 
   // Offset Table, zeroed for now
   size_t offset_table = offset;  // where to write offsets later
-  for (int i = 0; i < font_collection.fonts.size(); i++) {
+  for (size_t i = 0; i < font_collection.fonts.size(); i++) {
     StoreU32(0, &offset, dst);
   }
 
@@ -312,8 +312,7 @@ bool WriteFontCollection(const FontCollection& font_collection, uint8_t* dst,
   }
 
   // Write fonts and their offsets.
-  for (int i = 0; i < font_collection.fonts.size(); i++) {
-    const auto& font = font_collection.fonts[i];
+  for (const auto& font : font_collection.fonts) {
     StoreU32(offset, &offset_table, dst);
     if (!WriteFont(font, &offset, dst, dst_size)) {
       return false;

--- a/src/glyph.cc
+++ b/src/glyph.cc
@@ -122,7 +122,7 @@ bool ReadGlyph(const uint8_t* data, size_t len, Glyph* glyph) {
     uint8_t flag_repeat = 0;
     for (int i = 0; i < num_contours; ++i) {
       flags[i].resize(glyph->contours[i].size());
-      for (int j = 0; j < glyph->contours[i].size(); ++j) {
+      for (size_t j = 0; j < glyph->contours[i].size(); ++j) {
         if (flag_repeat == 0) {
           if (!buffer.ReadU8(&flag)) {
             return FONT_COMPRESSION_FAILURE();
@@ -143,7 +143,7 @@ bool ReadGlyph(const uint8_t* data, size_t len, Glyph* glyph) {
     // Read the x coordinates.
     int prev_x = 0;
     for (int i = 0; i < num_contours; ++i) {
-      for (int j = 0; j < glyph->contours[i].size(); ++j) {
+      for (size_t j = 0; j < glyph->contours[i].size(); ++j) {
         uint8_t flag = flags[i][j];
         if (flag & kFLAG_XSHORT) {
           // single byte x-delta coord value
@@ -170,7 +170,7 @@ bool ReadGlyph(const uint8_t* data, size_t len, Glyph* glyph) {
     // Read the y coordinates.
     int prev_y = 0;
     for (int i = 0; i < num_contours; ++i) {
-      for (int j = 0; j < glyph->contours[i].size(); ++j) {
+      for (size_t j = 0; j < glyph->contours[i].size(); ++j) {
         uint8_t flag = flags[i][j];
         if (flag & kFLAG_YSHORT) {
           // single byte y-delta coord value

--- a/src/transform.cc
+++ b/src/transform.cc
@@ -39,9 +39,7 @@ void WriteBytes(std::vector<uint8_t>* out, const uint8_t* data, size_t len) {
 }
 
 void WriteBytes(std::vector<uint8_t>* out, const std::vector<uint8_t>& in) {
-  for (int i = 0; i < in.size(); ++i) {
-    out->push_back(in[i]);
-  }
+  out->insert(out->end(), in.begin(), in.end());
 }
 
 void WriteUShort(std::vector<uint8_t>* out, int value) {

--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -670,9 +670,10 @@ bool ReconstructTransformedHmtx(const uint8_t* transformed_buf,
   Buffer glyf_buff(dst + glyf_table->dst_offset, glyf_table->dst_length);
   Buffer loca_buff(dst + loca_table->dst_offset, loca_table->dst_length);
   int16_t loca_format;
-  if (loca_table->dst_length == 2 * (num_glyphs + 1)) {
+  if (loca_table->dst_length == static_cast<uint32_t>(2 * (num_glyphs + 1))) {
     loca_format = 0;
-  } else if (loca_table->dst_length == 4 * (num_glyphs + 1)) {
+  } else if (loca_table->dst_length ==
+      static_cast<uint32_t>(4 * (num_glyphs + 1))) {
     loca_format = 1;
   } else {
     return FONT_COMPRESSION_FAILURE();
@@ -1329,7 +1330,7 @@ bool ConvertWOFF2ToTTF(uint8_t* result, size_t result_length,
     std::vector<Table> font_tables;
     for (const auto& ttc_font : ttc_fonts) {
       font_tables.resize(ttc_font.table_indices.size());
-      for (auto i = 0; i < ttc_font.table_indices.size(); i++) {
+      for (size_t i = 0; i < ttc_font.table_indices.size(); i++) {
         font_tables[i] = tables[ttc_font.table_indices[i]];
       }
       if (PREDICT_FALSE(!ReconstructTransformedFont(font_tables, &src_by_dest,


### PR DESCRIPTION
Chromium's Windows build configuration treats MSVC warning C4018 (signed/unsigned mismatch) as build error. We could tweak our compile options to ignore that, but I think it'd be better to fix because the woff2 decoder needs to handle font data in the wild.
