### PR TITLE
Don’t ignore write failure

### DIFF
--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -923,7 +923,10 @@ bool ReconstructFont(uint8_t* transformed_buf,
         table.dst_offset = dest_offset;
         checksum = ComputeULongSum(transformed_buf + table.src_offset,
                                    table.src_length);
-        out->Write(transformed_buf + table.src_offset, table.src_length);
+        if (PREDICT_FALSE(!out->Write(transformed_buf + table.src_offset,
+            table.src_length))) {
+          return FONT_COMPRESSION_FAILURE();
+        }
       } else {
         if (table.tag == kGlyfTableTag) {
           table.dst_offset = dest_offset;


### PR DESCRIPTION
Makes it easy to find the source of the problems than failing later.