### PR TITLE
Stop failing if path to a make binary contains spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,10 @@ $(EXECUTABLES) : $(EXE_OBJS) deps
 	$(CXX) $(LFLAGS) $(OBJS) $(ENCOBJ) $(DECOBJ) $(SRCDIR)/$@.o -o $@
 
 deps :
-	$(MAKE) -C $(BROTLI)/dec
-	$(MAKE) -C $(BROTLI)/enc
+	"$(MAKE)" -C $(BROTLI)/dec
+	"$(MAKE)" -C $(BROTLI)/enc
 
 clean :
 	rm -f $(OBJS) $(EXE_OBJS) $(EXECUTABLES)
-	$(MAKE) -C $(BROTLI)/dec clean
-	$(MAKE) -C $(BROTLI)/enc clean
+	"$(MAKE)" -C $(BROTLI)/dec clean
+	"$(MAKE)" -C $(BROTLI)/enc clean


### PR DESCRIPTION
For me it gets from a failing

```sh
/Volumes/Macintosh HD/Applications/Xcode.app/Contents/Developer/usr/bin/make -C brotli/dec clean
make: /Volumes/Macintosh: No such file or directory
```

to the successful

```sh
"/Volumes/Macintosh HD/Applications/Xcode.app/Contents/Developer/usr/bin/make" -C brotli/dec clean
```