### PR TITLE
Upgrade Brotli to v0.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,8 @@ $(EXECUTABLES) : $(EXE_OBJS) deps
 	$(CXX) $(LFLAGS) $(OBJS) $(ENCOBJ) $(DECOBJ) $(SRCDIR)/$@.o -o $@
 
 deps :
-	$(MAKE) -C $(BROTLI)/dec
-	$(MAKE) -C $(BROTLI)/enc
+	$(MAKE) -C $(BROTLI)
 
 clean :
 	rm -f $(OBJS) $(EXE_OBJS) $(EXECUTABLES)
-	$(MAKE) -C $(BROTLI)/dec clean
-	$(MAKE) -C $(BROTLI)/enc clean
+	$(MAKE) -C $(BROTLI) clean


### PR DESCRIPTION
This upgrades Brotli to v0.5, which is the latest available branch on GitHub.
