### PR TITLE
remove illegal `-f' ar option on Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,16 @@ CXX ?= g++
 CANONICAL_PREFIXES ?= -no-canonical-prefixes
 COMMON_FLAGS = -fno-omit-frame-pointer $(CANONICAL_PREFIXES) -DFONT_COMPRESSION_BIN -D __STDC_FORMAT_MACROS
 
+ARFLAGS = cr
+
 ifeq ($(OS), Darwin)
   CPPFLAGS += -DOS_MACOSX
 else
   COMMON_FLAGS += -fno-tree-vrp
+  ARFLAGS += f
 endif
 
-ARFLAGS = crf
+
 CFLAGS += $(COMMON_FLAGS)
 CXXFLAGS += $(COMMON_FLAGS) -std=c++11
 


### PR DESCRIPTION
This PR fixes compilation error on macOS 10.12
```
ar crf src/convert_woff2ttf_fuzzer.a  src/font.o  src/glyph.o  src/normalize.o  src/table_tags.o  src/transform.o  src/woff2_dec.o  src/woff2_enc.o  src/woff2_common.o  src/woff2_out.o  src/variable_length.o brotli/enc/*.o brotli/dec/*.o src/convert_woff2ttf_fuzzer.o
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar: illegal option -- f
usage:  ar -d [-TLsv] archive file ...
	ar -m [-TLsv] archive file ...
	ar -m [-abiTLsv] position archive file ...
	ar -p [-TLsv] archive [file ...]
	ar -q [-cTLsv] archive file ...
	ar -r [-cuTLsv] archive file ...
	ar -r [-abciuTLsv] position archive file ...
	ar -t [-TLsv] archive [file ...]
	ar -x [-ouTLsv] archive [file ...]
make: *** [convert_woff2ttf_fuzzer] Error 1
```

`man ar` suggests there is no `-f` option on `ar`.

This PR removes `-f` option to make it work on macOS. I am not sure if this option is vital on building process so any suggestions are welcome.