### PR TITLE
Output "info" log to stdout

### DIFF
--- a/src/woff2_enc.cc
+++ b/src/woff2_enc.cc
@@ -296,7 +296,7 @@ bool ConvertTTFToWOFF2(const uint8_t *data, size_t length,
   }
 
 #ifdef FONT_COMPRESSION_BIN
-  fprintf(stderr, "Compressed %zu to %u.\n", total_transform_length,
+  fprintf(stdout, "Compressed %zu to %u.\n", total_transform_length,
           total_compressed_length);
 #endif
 


### PR DESCRIPTION
```
Processing my/fonts/icons.ttf => my/fonts/icons.woff2
Compressed 27946 to 15681.
```

The `Compressed...` message would be "info" log but it is printed to stderr.
Because of this, some 3rd party tools which depends on woff2 (like [grunt-webfont](https://github.com/sapegin/grunt-webfont)) treats this result as error.