### PR TITLE
Move public headers into a separate include/woff2 directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OS := $(shell uname)
 
-CPPFLAGS = -I./brotli/c/include/ -I./src
+CPPFLAGS = -I./brotli/c/include/ -I./src -I./include
 
 AR ?= ar
 CC ?= gcc

--- a/include/woff2/decode.h
+++ b/include/woff2/decode.h
@@ -19,7 +19,7 @@
 
 #include <stddef.h>
 #include <inttypes.h>
-#include "./woff2_out.h"
+#include <woff2/output.h>
 
 namespace woff2 {
 

--- a/include/woff2/encode.h
+++ b/include/woff2/encode.h
@@ -21,16 +21,13 @@
 #include <inttypes.h>
 #include <string>
 
-using std::string;
-
-
 namespace woff2 {
 
 struct WOFF2Params {
   WOFF2Params() : extended_metadata(""), brotli_quality(11),
                   allow_transforms(true) {}
 
-  string extended_metadata;
+  std::string extended_metadata;
   int brotli_quality;
   bool allow_transforms;
 };
@@ -38,7 +35,7 @@ struct WOFF2Params {
 // Returns an upper bound on the size of the compressed file.
 size_t MaxWOFF2CompressedSize(const uint8_t* data, size_t length);
 size_t MaxWOFF2CompressedSize(const uint8_t* data, size_t length,
-                              const string& extended_metadata);
+                              const std::string& extended_metadata);
 
 // Compresses the font into the target buffer. *result_length should be at least
 // the value returned by MaxWOFF2CompressedSize(), upon return, it is set to the

--- a/include/woff2/output.h
+++ b/include/woff2/output.h
@@ -37,15 +37,11 @@
 #include <cstring>
 #include <memory>
 #include <string>
-#include "./port.h"
 
 namespace woff2 {
 
 // Suggested max size for output.
 const size_t kDefaultMaxSize = 30 * 1024 * 1024;
-
-using std::string;
-
 
 /**
  * Output interface for the woff2 decoding.
@@ -79,7 +75,7 @@ class WOFF2StringOut : public WOFF2Out {
   // Create a writer that writes its data to buf.
   // buf->size() will grow to at most max_size
   // buf may be sized (e.g. using EstimateWOFF2FinalSize) or empty.
-  explicit WOFF2StringOut(string* buf);
+  explicit WOFF2StringOut(std::string* buf);
 
   bool Write(const void *buf, size_t n) override;
   bool Write(const void *buf, size_t offset, size_t n) override;
@@ -87,7 +83,7 @@ class WOFF2StringOut : public WOFF2Out {
   size_t MaxSize() { return max_size_; }
   void SetMaxSize(size_t max_size);
  private:
-  string* buf_;
+  std::string* buf_;
   size_t max_size_;
   size_t offset_;
 };

--- a/src/convert_woff2ttf_fuzzer.cc
+++ b/src/convert_woff2ttf_fuzzer.cc
@@ -1,7 +1,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "woff2_dec.h"
+#include <woff2/decode.h>
 
 // Entry point for LibFuzzer.
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {

--- a/src/convert_woff2ttf_fuzzer_new_entry.cc
+++ b/src/convert_woff2ttf_fuzzer_new_entry.cc
@@ -1,5 +1,5 @@
 #include <string>
-#include "woff2_dec.h"
+#include <woff2/decode.h>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t data_size) {
   // Decode using newer entry pattern.

--- a/src/woff2_compress.cc
+++ b/src/woff2_compress.cc
@@ -17,7 +17,7 @@
 #include <string>
 
 #include "file.h"
-#include "./woff2_enc.h"
+#include <woff2/encode.h>
 
 
 int main(int argc, char **argv) {

--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -14,7 +14,7 @@
 //
 // Library for converting WOFF2 format font files to their TTF versions.
 
-#include "./woff2_dec.h"
+#include <woff2/decode.h>
 
 #include <stdlib.h>
 #include <algorithm>

--- a/src/woff2_decompress.cc
+++ b/src/woff2_decompress.cc
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "./file.h"
-#include "./woff2_dec.h"
+#include <woff2/decode.h>
 
 
 int main(int argc, char **argv) {

--- a/src/woff2_enc.cc
+++ b/src/woff2_enc.cc
@@ -14,7 +14,7 @@
 //
 // Library for converting TTF format font files to their WOFF2 versions.
 
-#include "./woff2_enc.h"
+#include <woff2/encode.h>
 
 #include <stdlib.h>
 #include <complex>

--- a/src/woff2_out.cc
+++ b/src/woff2_out.cc
@@ -14,7 +14,9 @@
 //
 // Output buffer for WOFF2 decompression.
 
-#include "./woff2_out.h"
+#include <woff2/output.h>
+
+using std::string;
 
 namespace woff2 {
 


### PR DESCRIPTION
 This is a first step to make WOFF2 a shared library. Public headers are moved
  in their own directory to make the public API clearer. This is similar to
  the c/include/brotli/ directory in Brotli. "using" commands are also removed from
  the public headers, so that callers won't have unexpected side effects when
  including the files.

This applies on top of https://github.com/google/woff2/pull/86