### PR TITLE
Include cassert for assert() declaration

### DIFF
--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -10,6 +10,7 @@
 
 #include <stdlib.h>
 #include <algorithm>
+#include <cassert>
 #include <complex>
 #include <cstring>
 #include <limits>


### PR DESCRIPTION
This fixes the following build fail:

/builddir/build/BUILD/webkitgtk-2.14.7/Source/ThirdParty/woff2/src/woff2_dec.cc: In function 'bool woff2::{anonymous}::ReconstructTransformedHmtx(const uint8_t*, size_t, uint16_t, uint16_t, const std::vector<short int>&, uint32_t*, woff2::WOFF2Out*)':
/builddir/build/BUILD/webkitgtk-2.14.7/Source/ThirdParty/woff2/src/woff2_dec.cc:693:37: error: 'assert' was not declared in this scope
   assert(x_mins.size() == num_glyphs);
                                     ^