### PR TITLE
cmake: Introduce a INSTALL_TOOLS build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ include(GNUInstallDirs)
 
 # Build options
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(INSTALL_TOOLS "Install tools when building shared libraries" OFF)
 option(CANONICAL_PREFIXES "Canonical prefixes" OFF)
 option(NOISY_LOGGING "Noisy logging" ON)
 
@@ -260,7 +261,7 @@ generate_pkg_config ("${CMAKE_CURRENT_BINARY_DIR}/libwoff2enc.pc"
   LIBRARIES woff2enc)
 
 # Installation
-if (NOT BUILD_SHARED_LIBS)
+if (NOT BUILD_SHARED_LIBS OR INSTALL_TOOLS)
   install(
     TARGETS woff2_decompress woff2_compress woff2_info
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"


### PR DESCRIPTION
Packagers and distributors which use the CMake-based build system may want to install the `woff2_{decompress,compress,info}` tools as well when building shared libraries. Using `cmake -DINSTALL_TOOLS=ON` allows that.

---

I found myself wanting to do the when writing an [Arch Linux package](https://aur.archlinux.org/cgit/aur.git/tree/?h=woff2) for `woff2-1.0.1`. Previously there was a [woff2-git package](https://aur.archlinux.org/cgit/aur.git/tree/?h=woff2-git) which only installed the tools, and therefore the package I made is expected to provide the tools as well because people who already had `woff2-git` installed and move over to the `woff2` package will expect them to be there.