### PR TITLE
Always install executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,12 +260,10 @@ generate_pkg_config ("${CMAKE_CURRENT_BINARY_DIR}/libwoff2enc.pc"
   LIBRARIES woff2enc)
 
 # Installation
-if (NOT BUILD_SHARED_LIBS)
-  install(
-    TARGETS woff2_decompress woff2_compress woff2_info
-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-  )
-endif()
+install(
+  TARGETS woff2_decompress woff2_compress woff2_info
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)
 
 install(
   TARGETS woff2common woff2dec woff2enc


### PR DESCRIPTION
When packaging for Debian, I want to install the shared libraries and the executables but I don't need static libraries. This commit works for me, but I don't really understand what the intent was here.

CC @fred-wang 