### PR TITLE
Add help, usage, and version options for woff2_compress + woff2_decompress

### DIFF
--- a/src/woff2_compress.cc
+++ b/src/woff2_compress.cc
@@ -6,18 +6,34 @@
 
 /* A commandline tool for compressing ttf format files to woff2. */
 
-#include <string>
-
-#include "file.h"
-#include <woff2/encode.h>
-
+#include "woff2_compress.h"
 
 int main(int argc, char **argv) {
   using std::string;
 
   if (argc != 2) {
-    fprintf(stderr, "One argument, the input filename, must be provided.\n");
+    fprintf(stderr, "Please include an argument with your command.\n");
     return 1;
+  }
+
+  std::string argument = argv[1];
+  if (argument == "--help" || argument == "-h") {
+      std::cout << APPLICATION << std::endl;
+      std::cout << AUTHOR << std::endl;
+      std::cout << LICENSE << std::endl;
+      std::cout << HELPSTRING << std::endl;
+      std::cout << "\n" + USAGESTRING << std::endl;
+      return 0;
+  }
+  
+  if (argument == "--usage") {
+      std::cout << USAGESTRING << std::endl;
+      return 0;
+  }
+
+  if (argument == "--version" || argument == "-v") {
+      std::cout << APPLICATION + " " + VERSION << std::endl;
+      return 0;
   }
 
   string filename(argv[1]);

--- a/src/woff2_compress.h
+++ b/src/woff2_compress.h
@@ -1,0 +1,24 @@
+/* Copyright 2018 Google Inc. All Rights Reserved.
+
+   Distributed under MIT license.
+   See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+*/
+
+#ifndef WOFF2_WOFF2_COMPRESS_H_
+#define WOFF2_WOFF2_COMPRESS_H_
+
+#include <string>
+#include <iostream>
+
+#include "file.h"
+#include <woff2/encode.h>
+
+#define VERSION string("v1.0.3")
+
+#define APPLICATION string("woff2_compress")
+#define AUTHOR string("Copyright 2013 Google Inc.")
+#define LICENSE string("MIT License")
+#define HELPSTRING string("\nInclude a single *.ttf or *.otf font file path argument to compile to a *.woff2 font file.")
+#define USAGESTRING string("Usage: woff2_compress [font file path]")
+
+#endif // WOFF2_WOFF2_COMPRESS_H_

--- a/src/woff2_decompress.cc
+++ b/src/woff2_decompress.cc
@@ -7,11 +7,7 @@
 /* A very simple commandline tool for decompressing woff2 format files to true
    type font files. */
 
-#include <string>
-
-#include "./file.h"
-#include <woff2/decode.h>
-
+#include "woff2_decompress.h"
 
 int main(int argc, char **argv) {
   using std::string;
@@ -19,6 +15,26 @@ int main(int argc, char **argv) {
   if (argc != 2) {
     fprintf(stderr, "One argument, the input filename, must be provided.\n");
     return 1;
+  }
+
+  std::string argument = argv[1];
+  if (argument == "--help" || argument == "-h") {
+      std::cout << APPLICATION << std::endl;
+      std::cout << AUTHOR << std::endl;
+      std::cout << LICENSE << std::endl;
+      std::cout << HELPSTRING << std::endl;
+      std::cout << "\n" + USAGESTRING << std::endl;
+      return 0;
+  }
+
+  if (argument == "--usage"){
+      std::cout << USAGESTRING << std::endl;
+      return 0;
+  }
+
+  if (argument == "--version" || argument == "-v") {
+      std::cout << APPLICATION + " " + VERSION << std::endl;
+      return 0;
   }
 
   string filename(argv[1]);

--- a/src/woff2_decompress.h
+++ b/src/woff2_decompress.h
@@ -1,0 +1,24 @@
+/* Copyright 2018 Google Inc. All Rights Reserved.
+
+   Distributed under MIT license.
+   See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+*/
+
+#ifndef WOFF2_WOFF2_DECOMPRESS_H_
+#define WOFF2_WOFF2_DECOMPRESS_H_
+
+#include <string>
+#include <iostream>
+
+#include "file.h"
+#include <woff2/decode.h>
+
+#define VERSION string("v1.0.3")
+
+#define APPLICATION string("woff2_decompress")
+#define AUTHOR string("Copyright 2013 Google Inc.")
+#define LICENSE string("MIT License")
+#define HELPSTRING string("\nInclude a single *.woff2 font file path as an argument to decode to a *.ttf font.")
+#define USAGESTRING string("Usage: woff2_decompress [font file path]")
+
+#endif // WOFF2_WOFF2_DECOMPRESS_H_


### PR DESCRIPTION
I needed to be able to check the woff2_compress version from the executable.

This PR adds help (`--help` and `-h`), usage (`--usage`), and version (`--version` and `-v`) command line options to the woff2_compress and woff2_decompress executables with very minimal command line documentation.

Adds two new header files that contain the string literals.  There is likely be a better approach to implement the version strings during the build process.  Happy to modify to whatever approach is appropriate/better if there is any interest in supporting these command line options.

