### PR TITLE
Add functions to get the version numbers of the libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ option(NOISY_LOGGING "Noisy logging" ON)
 # Version information
 set(WOFF2_VERSION 1.0.2)
 
+string(REPLACE "." ";" WOFF2_VERSION_COMPONENTS ${WOFF2_VERSION})
+list(GET WOFF2_VERSION_COMPONENTS 0 WOFF2_VERSION_MAJOR)
+list(GET WOFF2_VERSION_COMPONENTS 1 WOFF2_VERSION_MINOR)
+list(GET WOFF2_VERSION_COMPONENTS 2 WOFF2_VERSION_PATCH)
+
 # When building shared libraries it is important to set the correct rpath
 # See https://cmake.org/Wiki/CMake_RPATH_handling#Always_full_RPATH
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
@@ -30,6 +35,8 @@ list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_LIBDIR}" isS
 if ("${isSystemDir}" STREQUAL "-1")
   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}")
 endif()
+
+configure_file(src/version.h.in src/version.h NEWLINE_STYLE UNIX)
 
 # Find Brotli dependencies
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -64,7 +71,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_FLAG}")
 set(CMAKE_CXX_STANDARD 11)
 
 # Set search path for our private/public headers as well as Brotli headers
-include_directories("src" "include"
+include_directories("src" "include" "${CMAKE_CURRENT_BINARY_DIR}/src"
                     "${BROTLIDEC_INCLUDE_DIRS}" "${BROTLIENC_INCLUDE_DIRS}")
 
 # Common part used by decoder and encoder

--- a/include/woff2/decode.h
+++ b/include/woff2/decode.h
@@ -31,6 +31,9 @@ bool ConvertWOFF2ToTTF(uint8_t *result, size_t result_length,
 bool ConvertWOFF2ToTTF(const uint8_t *data, size_t length,
                        WOFF2Out* out);
 
+// Returns the woff2 decoder version.
+uint32_t DecoderVersion (void);
+
 } // namespace woff2
 
 #endif  // WOFF2_WOFF2_DEC_H_

--- a/include/woff2/encode.h
+++ b/include/woff2/encode.h
@@ -38,6 +38,9 @@ bool ConvertTTFToWOFF2(const uint8_t *data, size_t length,
                        uint8_t *result, size_t *result_length,
                        const WOFF2Params& params);
 
+// Returns the woff2 encoder version.
+uint32_t EncoderVersion (void);
+
 } // namespace woff2
 
 #endif  // WOFF2_WOFF2_ENC_H_

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,0 +1,11 @@
+#ifndef WOFF2_VERSION_H
+#define WOFF2_VERSION_H
+
+/* Semantic version, calculated as (MAJOR << 24) | (MINOR << 12) | PATCH */
+#define WOFF2_VERSION \
+	(@WOFF2_VERSION_MAJOR@ << 24) | \
+	(@WOFF2_VERSION_MINOR@ << 12) | \
+	(@WOFF2_VERSION_PATCH@)
+
+#endif
+

--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -27,6 +27,7 @@
 #include "./table_tags.h"
 #include "./variable_length.h"
 #include "./woff2_common.h"
+#include "./version.h"
 
 namespace woff2 {
 
@@ -1366,6 +1367,10 @@ bool ConvertWOFF2ToTTF(const uint8_t* data, size_t length,
   }
 
   return true;
+}
+
+uint32_t DecoderVersion (void) {
+	return WOFF2_VERSION;
 }
 
 } // namespace woff2

--- a/src/woff2_enc.cc
+++ b/src/woff2_enc.cc
@@ -25,6 +25,7 @@
 #include "./transform.h"
 #include "./variable_length.h"
 #include "./woff2_common.h"
+#include "./version.h"
 
 namespace woff2 {
 
@@ -457,6 +458,10 @@ fprintf(stderr, "Missing table index for offset 0x%08x\n",
     return FONT_COMPRESSION_FAILURE();
   }
   return true;
+}
+
+uint32_t EncoderVersion (void) {
+	return WOFF2_VERSION;
 }
 
 } // namespace woff2


### PR DESCRIPTION
Currently, it's not possible to receive the version number of the woff2 libraries at runtime. Therefore, I added the two functions `woff2::EncoderVersion` and `woff2::DecoderVersion` similar to those provided by brotli.