### PR TITLE
fix links in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@ the end).
 
 ### Before you contribute
 Before we can use your code, you must sign the
-[Google Individual Contributor License Agreement]
-(https://cla.developers.google.com/about/google-individual)
+[Google Individual Contributor License
+Agreement](https://cla.developers.google.com/about/google-individual)
 (CLA), which you can do online. The CLA is necessary mainly because you own the
 copyright to your changes, even after your contribution becomes part of our
 codebase, so we need your permission to use and distribute your code. We also
@@ -23,5 +23,5 @@ use Github pull requests for this purpose.
 
 ### The small print
 Contributions made by corporations are covered by a different agreement than
-the one above, the [Software Grant and Corporate Contributor License Agreement]
-(https://cla.developers.google.com/about/google-corporate).
+the one above, the [Software Grant and Corporate Contributor License
+Agreement](https://cla.developers.google.com/about/google-corporate).

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ woff2_decompress myfont.woff2
 
 # References
 
-http://www.w3.org/TR/WOFF2/
-http://www.w3.org/Submission/MTX/
+* https://www.w3.org/TR/WOFF2/
+* https://www.w3.org/Submission/MTX/
 
 Also please refer to documents (currently Google Docs):
 


### PR DESCRIPTION
There shouldn't be a space between the brackets and parentheses in Markdown links.