### PR TITLE
Enable transformation for the hmtx table

### DIFF
--- a/src/woff2_enc.cc
+++ b/src/woff2_enc.cc
@@ -14,6 +14,7 @@
 #include <limits>
 #include <string>
 #include <vector>
+#include <iostream>
 
 #include <brotli/encode.h>
 #include "./buffer.h"
@@ -200,6 +201,13 @@ bool TransformFontCollection(FontCollection* font_collection) {
     if (!TransformGlyfAndLocaTables(&font)) {
 #ifdef FONT_COMPRESSION_BIN
       fprintf(stderr, "glyf/loca transformation failed.\n");
+#endif
+      return FONT_COMPRESSION_FAILURE();
+    }
+
+    if (!TransformHmtxTable(&font)) {
+#ifdef FONT_COMPRESSION_BIN
+      fprintf(stderr, "hmtx transformation failed.\n");
 #endif
       return FONT_COMPRESSION_FAILURE();
     }


### PR DESCRIPTION
Unless I'm really missing something, it looks like the hmtx transformation is never applied, i.e. the `TransformHmtxTable` function is never called. This explains why running `woff2_compress` on a monospace font never results in a .woff2 font with a transformed hmtx table.