### PR TITLE
Add woff2 encoder/decoder support for overlapSimpleBitmap.

### DIFF
--- a/include/woff2/encode.h
+++ b/include/woff2/encode.h
@@ -26,8 +26,8 @@ struct WOFF2Params {
 
 // Returns an upper bound on the size of the compressed file.
 size_t MaxWOFF2CompressedSize(const uint8_t* data, size_t length);
-size_t MaxWOFF2CompressedSize(const uint8_t* data, size_t length,
-                              const std::string& extended_metadata);
+size_t MaxWOFF2CompressedSize(const uint8_t *data, size_t length,
+                              const std::string &extended_metadata);
 
 // Compresses the font into the target buffer. *result_length should be at least
 // the value returned by MaxWOFF2CompressedSize(), upon return, it is set to the

--- a/include/woff2/output.h
+++ b/include/woff2/output.h
@@ -51,7 +51,7 @@ class WOFF2StringOut : public WOFF2Out {
   // Create a writer that writes its data to buf.
   // buf->size() will grow to at most max_size
   // buf may be sized (e.g. using EstimateWOFF2FinalSize) or empty.
-  explicit WOFF2StringOut(std::string* buf);
+  explicit WOFF2StringOut(std::string *buf);
 
   bool Write(const void *buf, size_t n) override;
   bool Write(const void *buf, size_t offset, size_t n) override;
@@ -59,7 +59,7 @@ class WOFF2StringOut : public WOFF2Out {
   size_t MaxSize() { return max_size_; }
   void SetMaxSize(size_t max_size);
  private:
-  std::string* buf_;
+  std::string *buf_;
   size_t max_size_;
   size_t offset_;
 };

--- a/src/file.h
+++ b/src/file.h
@@ -14,18 +14,14 @@
 
 namespace woff2 {
 
-using std::string;
-
-
-inline string GetFileContent(string filename) {
+inline std::string GetFileContent(std::string filename) {
   std::ifstream ifs(filename.c_str(), std::ios::binary);
-  return string(
-    std::istreambuf_iterator<char>(ifs.rdbuf()),
-    std::istreambuf_iterator<char>());
+  return std::string(std::istreambuf_iterator<char>(ifs.rdbuf()),
+                     std::istreambuf_iterator<char>());
 }
 
-inline void SetFileContents(string filename, string::iterator start,
-    string::iterator end) {
+inline void SetFileContents(std::string filename, std::string::iterator start,
+                            std::string::iterator end) {
   std::ofstream ofs(filename.c_str(), std::ios::binary);
   std::copy(start, end, std::ostream_iterator<char>(ofs));
 }

--- a/src/glyph.h
+++ b/src/glyph.h
@@ -10,8 +10,10 @@
 #ifndef WOFF2_GLYPH_H_
 #define WOFF2_GLYPH_H_
 
-#include <stddef.h>
 #include <inttypes.h>
+#include <stddef.h>
+
+#include <cstdint>
 #include <vector>
 
 namespace woff2 {
@@ -22,7 +24,10 @@ namespace woff2 {
 // is around.
 class Glyph {
  public:
-  Glyph() : instructions_size(0), composite_data_size(0) {}
+  Glyph()
+      : instructions_size(0),
+        overlap_simple_flag_set(false),
+        composite_data_size(0) {}
 
   // Bounding box.
   int16_t x_min;
@@ -33,6 +38,9 @@ class Glyph {
   // Instructions.
   uint16_t instructions_size;
   const uint8_t* instructions_data;
+
+  // Flags.
+  bool overlap_simple_flag_set;
 
   // Data model for simple glyphs.
   struct Point {

--- a/src/woff2_compress.cc
+++ b/src/woff2_compress.cc
@@ -13,22 +13,20 @@
 
 
 int main(int argc, char **argv) {
-  using std::string;
-
   if (argc != 2) {
     fprintf(stderr, "One argument, the input filename, must be provided.\n");
     return 1;
   }
 
-  string filename(argv[1]);
-  string outfilename = filename.substr(0, filename.find_last_of(".")) + ".woff2";
+  std::string filename(argv[1]);
+  std::string outfilename = filename.substr(0, filename.find_last_of(".")) + ".woff2";
   fprintf(stdout, "Processing %s => %s\n",
     filename.c_str(), outfilename.c_str());
-  string input = woff2::GetFileContent(filename);
+  std::string input = woff2::GetFileContent(filename);
 
   const uint8_t* input_data = reinterpret_cast<const uint8_t*>(input.data());
   size_t output_size = woff2::MaxWOFF2CompressedSize(input_data, input.size());
-  string output(output_size, 0);
+  std::string output(output_size, 0);
   uint8_t* output_data = reinterpret_cast<uint8_t*>(&output[0]);
 
   woff2::WOFF2Params params;

--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -32,10 +32,6 @@ namespace woff2 {
 
 namespace {
 
-using std::string;
-using std::vector;
-
-
 // simple glyph flags
 const int kGlyfOnCurve = 1 << 0;
 const int kGlyfXShort = 1 << 1;
@@ -43,6 +39,7 @@ const int kGlyfYShort = 1 << 2;
 const int kGlyfRepeat = 1 << 3;
 const int kGlyfThisXIsSame = 1 << 4;
 const int kGlyfThisYIsSame = 1 << 5;
+const int kOverlapSimple = 1 << 6;
 
 // composite glyph flags
 // See CompositeGlyph.java in sfntly for full definitions
@@ -52,6 +49,9 @@ const int FLAG_MORE_COMPONENTS = 1 << 5;
 const int FLAG_WE_HAVE_AN_X_AND_Y_SCALE = 1 << 6;
 const int FLAG_WE_HAVE_A_TWO_BY_TWO = 1 << 7;
 const int FLAG_WE_HAVE_INSTRUCTIONS = 1 << 8;
+
+// glyf flags
+const int FLAG_OVERLAP_SIMPLE_BITMAP = 1 << 0;
 
 const size_t kCheckSumAdjustmentOffset = 8;
 
@@ -191,8 +191,9 @@ bool TripletDecode(const uint8_t* flags_in, const uint8_t* in, size_t in_size,
 // This function stores just the point data. On entry, dst points to the
 // beginning of a simple glyph. Returns true on success.
 bool StorePoints(unsigned int n_points, const Point* points,
-    unsigned int n_contours, unsigned int instruction_length,
-    uint8_t* dst, size_t dst_size, size_t* glyph_size) {
+                 unsigned int n_contours, unsigned int instruction_length,
+                 bool has_overlap_bit, uint8_t* dst, size_t dst_size,
+                 size_t* glyph_size) {
   // I believe that n_contours < 65536, in which case this is safe. However, a
   // comment and/or an assert would be good.
   unsigned int flag_offset = kEndPtsOfContoursOffset + 2 * n_contours + 2 +
@@ -207,6 +208,10 @@ bool StorePoints(unsigned int n_points, const Point* points,
   for (unsigned int i = 0; i < n_points; ++i) {
     const Point& point = points[i];
     int flag = point.on_curve ? kGlyfOnCurve : 0;
+    if (has_overlap_bit && i == 0) {
+      flag |= kOverlapSimple;
+    }
+
     int dx = point.x - last_x;
     int dy = point.y - last_y;
     if (dx == 0) {
@@ -404,13 +409,20 @@ bool ReconstructGlyf(const uint8_t* data, Table* glyf_table,
                      WOFF2Out* out) {
   static const int kNumSubStreams = 7;
   Buffer file(data, glyf_table->transform_length);
-  uint32_t version;
+  uint16_t version;
   std::vector<std::pair<const uint8_t*, size_t> > substreams(kNumSubStreams);
   const size_t glyf_start = out->Size();
 
-  if (PREDICT_FALSE(!file.ReadU32(&version))) {
+  if (PREDICT_FALSE(!file.ReadU16(&version))) {
     return FONT_COMPRESSION_FAILURE();
   }
+
+  uint16_t flags;
+  if (PREDICT_FALSE(!file.ReadU16(&flags))) {
+    return FONT_COMPRESSION_FAILURE();
+  }
+  bool has_overlap_bitmap = (flags & FLAG_OVERLAP_SIMPLE_BITMAP);
+
   if (PREDICT_FALSE(!file.ReadU16(&info->num_glyphs) ||
       !file.ReadU16(&info->index_format))) {
     return FONT_COMPRESSION_FAILURE();
@@ -447,6 +459,17 @@ bool ReconstructGlyf(const uint8_t* data, Table* glyf_table,
   Buffer composite_stream(substreams[4].first, substreams[4].second);
   Buffer bbox_stream(substreams[5].first, substreams[5].second);
   Buffer instruction_stream(substreams[6].first, substreams[6].second);
+
+  const uint8_t* overlap_bitmap = nullptr;
+  unsigned int overlap_bitmap_length = 0;
+  if (has_overlap_bitmap) {
+    overlap_bitmap_length = (info->num_glyphs + 7) >> 3;
+    overlap_bitmap = data + offset;
+    if (PREDICT_FALSE(overlap_bitmap_length >
+                           glyf_table->transform_length - offset)) {
+      return FONT_COMPRESSION_FAILURE();
+    }
+  }
 
   std::vector<uint32_t> loca_values(info->num_glyphs + 1);
   std::vector<unsigned int> n_points_vec;
@@ -601,8 +624,12 @@ bool ReconstructGlyf(const uint8_t* data, Table* glyf_table,
       }
       glyph_size += instruction_size;
 
-      if (PREDICT_FALSE(!StorePoints(total_n_points, points.get(), n_contours,
-            instruction_size, glyph_buf.get(), glyph_buf_size, &glyph_size))) {
+      bool has_overlap_bit =
+          has_overlap_bitmap && overlap_bitmap[i >> 3] & (0x80 >> (i & 7));
+
+      if (PREDICT_FALSE(!StorePoints(
+              total_n_points, points.get(), n_contours, instruction_size,
+              has_overlap_bit, glyph_buf.get(), glyph_buf_size, &glyph_size))) {
         return FONT_COMPRESSION_FAILURE();
       }
     } else {

--- a/src/woff2_decompress.cc
+++ b/src/woff2_decompress.cc
@@ -14,21 +14,21 @@
 
 
 int main(int argc, char **argv) {
-  using std::string;
-
   if (argc != 2) {
     fprintf(stderr, "One argument, the input filename, must be provided.\n");
     return 1;
   }
 
-  string filename(argv[1]);
-  string outfilename = filename.substr(0, filename.find_last_of(".")) + ".ttf";
+  std::string filename(argv[1]);
+  std::string outfilename = filename.substr(0, filename.find_last_of(".")) + ".ttf";
 
   // Note: update woff2_dec_fuzzer_new_entry.cc if this pattern changes.
-  string input = woff2::GetFileContent(filename);
+  std::string input = woff2::GetFileContent(filename);
   const uint8_t* raw_input = reinterpret_cast<const uint8_t*>(input.data());
-  string output(std::min(woff2::ComputeWOFF2FinalSize(raw_input, input.size()),
-                         woff2::kDefaultMaxSize), 0);
+  std::string output(
+      std::min(woff2::ComputeWOFF2FinalSize(raw_input, input.size()),
+               woff2::kDefaultMaxSize),
+      0);
   woff2::WOFF2StringOut out(&output);
 
   const bool ok = woff2::ConvertWOFF2ToTTF(raw_input, input.size(), &out);

--- a/src/woff2_enc.cc
+++ b/src/woff2_enc.cc
@@ -28,12 +28,8 @@
 
 namespace woff2 {
 
+
 namespace {
-
-
-using std::string;
-using std::vector;
-
 
 const size_t kWoff2HeaderSize = 48;
 const size_t kWoff2EntrySize = 20;
@@ -183,7 +179,7 @@ size_t MaxWOFF2CompressedSize(const uint8_t* data, size_t length) {
 }
 
 size_t MaxWOFF2CompressedSize(const uint8_t* data, size_t length,
-    const string& extended_metadata) {
+                              const std::string& extended_metadata) {
   // Except for the header size, which is 32 bytes larger in woff2 format,
   // all other parts should be smaller (table header in short format,
   // transformations and compression). Just to be sure, we will give some

--- a/src/woff2_info.cc
+++ b/src/woff2_info.cc
@@ -29,18 +29,16 @@ std::string PrintTag(int tag) {
 }
 
 int main(int argc, char **argv) {
-  using std::string;
-
   if (argc != 2) {
     fprintf(stderr, "One argument, the input filename, must be provided.\n");
     return 1;
   }
 
-  string filename(argv[1]);
-  string outfilename = filename.substr(0, filename.find_last_of(".")) + ".woff2";
+  std::string filename(argv[1]);
+  std::string outfilename = filename.substr(0, filename.find_last_of(".")) + ".woff2";
   fprintf(stdout, "Processing %s => %s\n",
     filename.c_str(), outfilename.c_str());
-  string input = woff2::GetFileContent(filename);
+  std::string input = woff2::GetFileContent(filename);
 
   woff2::Buffer file(reinterpret_cast<const uint8_t*>(input.data()),
     input.size());

--- a/src/woff2_out.cc
+++ b/src/woff2_out.cc
@@ -8,14 +8,10 @@
 
 #include <woff2/output.h>
 
-using std::string;
-
 namespace woff2 {
 
-WOFF2StringOut::WOFF2StringOut(string* buf)
-  : buf_(buf),
-    max_size_(kDefaultMaxSize),
-    offset_(0) {}
+WOFF2StringOut::WOFF2StringOut(std::string *buf)
+    : buf_(buf), max_size_(kDefaultMaxSize), offset_(0) {}
 
 bool WOFF2StringOut::Write(const void *buf, size_t n) {
   return Write(buf, offset_, n);


### PR DESCRIPTION
overlapSimpleBitmap is a new field in the transformed glyf table (https://www.w3.org/TR/WOFF2/#glyf_table_format). It allows the overlap simple flag set on glyphs in the original font to be saved into the woff2 encoding.