### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ make
 make install
 ```
 
+Alternatively, You can build and install woff2 using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+./vcpkg integrate install
+./vcpkg install woff2
+```
+
+The woff2 port in vcpkg is kept up to date by Microsoft team members and community contributors. 
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+
 ## Run
 
 Ensure the binaries from the build process are in your $PATH, then:


### PR DESCRIPTION
Woff2 is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for woff2 and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build woff2, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/woff2/portfile.cmake). We try to keep the library maintained as close as possible to the original library.