### PR TITLE
include/woff2/output.h: add missing <stdint.h> include

### DIFF
--- a/include/woff2/output.h
+++ b/include/woff2/output.h
@@ -9,6 +9,8 @@
 #ifndef WOFF2_WOFF2_OUT_H_
 #define WOFF2_WOFF2_OUT_H_
 
+#include <stdint.h>
+
 #include <algorithm>
 #include <cstring>
 #include <memory>


### PR DESCRIPTION
Without the change `woff2` build fails on upcoming `gcc-15` as:

    In file included from src/woff2_out.cc:9:
    include/woff2/output.h:73:25: error: expected ')' before '*' token
       73 |   WOFF2MemoryOut(uint8_t* buf, size_t buf_size);
          |                 ~       ^
          |                         )
    include/woff2/output.h:79:3: error: 'uint8_t' does not name a type
       79 |   uint8_t* buf_;
          |   ^~~~~~~
    include/woff2/output.h:16:1: note: 'uint8_t' is defined in header '<cstdint>';
      this is probably fixable by adding '#include <cstdint>'
       15 | #include <string>
      +++ |+#include <cstdint>
       16 |