### PR TITLE
Spanify woff2_dec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_FLAG}")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_FLAG}")
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 
 # Set search path for our private/public headers as well as Brotli headers
 include_directories("src" "include"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,9 @@ add_library(convert_woff2ttf_fuzzer STATIC src/convert_woff2ttf_fuzzer.cc)
 target_link_libraries(convert_woff2ttf_fuzzer woff2dec)
 add_library(convert_woff2ttf_fuzzer_new_entry STATIC src/convert_woff2ttf_fuzzer_new_entry.cc)
 target_link_libraries(convert_woff2ttf_fuzzer_new_entry woff2dec)
+add_library(enc_dec_fuzzer STATIC src/enc_dec_fuzzer.cc)
+target_link_libraries(enc_dec_fuzzer woff2dec woff2enc)
+# clang++ -fsanitize=fuzzer -o enc_dec_fuzzer libwoff2common.so libwoff2dec.so libwoff2enc.so libenc_dec_fuzzer.a
 
 # PC files
 include(CMakeParseArguments)

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ COMMONOBJ = $(BROTLIOBJ)/common/*.o
 OBJS = $(patsubst %, $(SRCDIR)/%, $(OUROBJ))
 EXECUTABLES=woff2_compress woff2_decompress woff2_info
 EXE_OBJS=$(patsubst %, $(SRCDIR)/%.o, $(EXECUTABLES))
-ARCHIVES=convert_woff2ttf_fuzzer convert_woff2ttf_fuzzer_new_entry
+ARCHIVES=convert_woff2ttf_fuzzer convert_woff2ttf_fuzzer_new_entry enc_dec_fuzzer
 ARCHIVE_OBJS=$(patsubst %, $(SRCDIR)/%.o, $(ARCHIVES))
 
 ifeq (,$(wildcard $(BROTLI)/*))

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 
 
 CFLAGS += $(COMMON_FLAGS)
-CXXFLAGS += $(COMMON_FLAGS) -std=c++11
+CXXFLAGS += $(COMMON_FLAGS) -std=c++20
 
 SRCDIR = src
 

--- a/src/enc_dec_fuzzer.cc
+++ b/src/enc_dec_fuzzer.cc
@@ -1,0 +1,52 @@
+#include <woff2/decode.h>
+#include <woff2/encode.h>
+
+#include <string>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t data_size) {
+  size_t encoded_size = woff2::MaxWOFF2CompressedSize(data, data_size);
+  std::string encoded(encoded_size, 0);
+  uint8_t* encoded_data = reinterpret_cast<uint8_t*>(&encoded[0]);
+
+  woff2::WOFF2Params params;
+  if (!woff2::ConvertTTFToWOFF2(data, data_size, encoded_data, &encoded_size,
+                                params)) {
+    // Do not record this in the corpus
+    return -1;
+  }
+  encoded.resize(encoded_size);
+
+  // Decode using newer entry pattern.
+  // Same pattern as woff2_decompress.
+  std::string decoded_output(
+      std::min(woff2::ComputeWOFF2FinalSize(encoded_data, encoded.size()),
+               woff2::kDefaultMaxSize),
+      0);
+  woff2::WOFF2StringOut out(&decoded_output);
+  woff2::ConvertWOFF2ToTTF(encoded_data, encoded.size(), &out);
+
+  // Convert back to encoded version.
+  size_t re_encoded_size = encoded_size;
+  std::string re_encoded(re_encoded_size, 0);
+  uint8_t* re_encoded_data = reinterpret_cast<uint8_t*>(&re_encoded[0]);
+  if (!woff2::ConvertTTFToWOFF2(
+          reinterpret_cast<const uint8_t*>(decoded_output.data()),
+          decoded_output.size(), re_encoded_data, &re_encoded_size, params)) {
+    fprintf(stderr, "Compression failed.\n");
+    return -1;
+  }
+  re_encoded.resize(re_encoded_size);
+
+  // Compressed data == compressed/decompressed/compressed data.
+  // Note that compressed/decompressed may not be the same as the original data
+  // provided by libfuzzer because our decompression may output a slightly
+  // different but functionally equivalent TTF file.
+  if (encoded_size != re_encoded_size) {
+    __builtin_trap();
+  }
+  if (memcmp(encoded.data(), re_encoded.data(), encoded_size) != 0) {
+    __builtin_trap();
+  }
+
+  return 0;
+}

--- a/src/glyph.cc
+++ b/src/glyph.cc
@@ -31,7 +31,7 @@ static const int32_t kFLAG_WE_HAVE_INSTRUCTIONS = 1 << 8;
 
 bool ReadCompositeGlyphData(Buffer* buffer, Glyph* glyph) {
   glyph->have_instructions = false;
-  glyph->composite_data = buffer->buffer() + buffer->offset();
+  glyph->composite_data = buffer->remaining_buffer().data();
   size_t start_offset = buffer->offset();
   uint16_t flags = kFLAG_MORE_COMPONENTS;
   while (flags & kFLAG_MORE_COMPONENTS) {

--- a/src/normalize.cc
+++ b/src/normalize.cc
@@ -219,7 +219,7 @@ bool FixChecksums(Font* font) {
     if (table->IsReused()) {
       table = table->reuse_of;
     }
-    table->checksum = ComputeULongSum(table->data, table->length);
+    table->checksum = ComputeULongSum(std::span(table->data, table->length));
     file_checksum += table->checksum;
 
     if (table->tag == kHeadTableTag) {

--- a/src/store_bytes.h
+++ b/src/store_bytes.h
@@ -14,11 +14,13 @@
 #include <stddef.h>
 #include <string.h>
 
+#include <span>
+
 #include "./port.h"
 
 namespace woff2 {
 
-inline size_t StoreU32(uint8_t* dst, size_t offset, uint32_t x) {
+inline size_t StoreU32(std::span<uint8_t> dst, size_t offset, uint32_t x) {
   dst[offset] = x >> 24;
   dst[offset + 1] = x >> 16;
   dst[offset + 2] = x >> 8;
@@ -26,28 +28,51 @@ inline size_t StoreU32(uint8_t* dst, size_t offset, uint32_t x) {
   return offset + 4;
 }
 
-inline size_t Store16(uint8_t* dst, size_t offset, int x) {
+inline size_t Store16(std::span<uint8_t> dst, size_t offset, int x) {
   dst[offset] = x >> 8;
   dst[offset + 1] = x;
   return offset + 2;
 }
 
-inline void StoreU32(uint32_t val, size_t* offset, uint8_t* dst) {
+inline void StoreU32(uint32_t val, size_t* offset, std::span<uint8_t> dst) {
   dst[(*offset)++] = val >> 24;
   dst[(*offset)++] = val >> 16;
   dst[(*offset)++] = val >> 8;
   dst[(*offset)++] = val;
 }
 
-inline void Store16(int val, size_t* offset, uint8_t* dst) {
+inline void Store16(int val, size_t* offset, std::span<uint8_t> dst) {
   dst[(*offset)++] = val >> 8;
   dst[(*offset)++] = val;
 }
 
+inline void StoreBytes(std::span<const uint8_t> data,
+                       size_t* offset, std::span<uint8_t> dst) {
+  std::copy(data.begin(), data.end(), &dst[*offset]);
+  *offset += data.size_bytes();
+}
+
+// Same as above, but with less safety.
+
+inline size_t StoreU32(uint8_t* dst, size_t offset, uint32_t x) {
+  return StoreU32(std::span(dst, sizeof(uint32_t)), offset, x);
+}
+
+inline size_t Store16(uint8_t* dst, size_t offset, int x) {
+  return Store16(std::span(dst, sizeof(uint16_t)), offset, x);
+}
+
+inline void StoreU32(uint32_t val, size_t* offset, uint8_t* dst) {
+  StoreU32(val, offset, std::span(dst, sizeof(uint32_t)));
+}
+
+inline void Store16(int val, size_t* offset, uint8_t* dst) {
+  return Store16(val, offset, std::span(dst, sizeof(uint16_t)));
+}
+
 inline void StoreBytes(const uint8_t* data, size_t len,
                        size_t* offset, uint8_t* dst) {
-  memcpy(&dst[*offset], data, len);
-  *offset += len;
+  StoreBytes(std::span(data, len), offset, std::span(dst, len));
 }
 
 } // namespace woff2

--- a/src/woff2_common.cc
+++ b/src/woff2_common.cc
@@ -35,10 +35,6 @@ uint32_t ComputeULongSum(std::span<const uint8_t> buf) {
   return checksum;
 }
 
-uint32_t ComputeULongSum(const uint8_t* buf, size_t size) {
-  return ComputeULongSum(std::span(buf, size));
-}
-
 size_t CollectionHeaderSize(uint32_t header_version, uint32_t num_fonts) {
   size_t size = 0;
   if (header_version == 0x00020000) {

--- a/src/woff2_common.h
+++ b/src/woff2_common.h
@@ -12,6 +12,7 @@
 #include <stddef.h>
 #include <inttypes.h>
 
+#include <span>
 #include <string>
 
 namespace woff2 {
@@ -57,6 +58,7 @@ struct Table {
 size_t CollectionHeaderSize(uint32_t header_version, uint32_t num_fonts);
 
 // Compute checksum over size bytes of buf
+uint32_t ComputeULongSum(std::span<const uint8_t> buf);
 uint32_t ComputeULongSum(const uint8_t* buf, size_t size);
 
 } // namespace woff2

--- a/src/woff2_common.h
+++ b/src/woff2_common.h
@@ -57,9 +57,8 @@ struct Table {
 // True Type Collections
 size_t CollectionHeaderSize(uint32_t header_version, uint32_t num_fonts);
 
-// Compute checksum over size bytes of buf
+// Compute checksum over buf
 uint32_t ComputeULongSum(std::span<const uint8_t> buf);
-uint32_t ComputeULongSum(const uint8_t* buf, size_t size);
 
 } // namespace woff2
 

--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -527,20 +527,21 @@ bool ReconstructGlyf(std::span<const uint8_t> data, Table* glyf_table,
       }
 
       glyph_size = Store16(glyph_buf_view, glyph_size, n_contours);
-      if (PREDICT_FALSE(!bbox_stream.Read(glyph_buf.get() + glyph_size, 8))) {
+      if (PREDICT_FALSE(
+              !bbox_stream.Read(glyph_buf_view.subspan(glyph_size), 8))) {
         return FONT_COMPRESSION_FAILURE();
       }
       glyph_size += 8;
 
-      if (PREDICT_FALSE(!composite_stream.Read(glyph_buf.get() + glyph_size,
-            composite_size))) {
+      if (PREDICT_FALSE(!composite_stream.Read(
+              glyph_buf_view.subspan(glyph_size), composite_size))) {
         return FONT_COMPRESSION_FAILURE();
       }
       glyph_size += composite_size;
       if (have_instructions) {
         glyph_size = Store16(glyph_buf_view, glyph_size, instruction_size);
-        if (PREDICT_FALSE(!instruction_stream.Read(glyph_buf.get() + glyph_size,
-              instruction_size))) {
+        if (PREDICT_FALSE(!instruction_stream.Read(
+                glyph_buf_view.subspan(glyph_size), instruction_size))) {
           return FONT_COMPRESSION_FAILURE();
         }
         glyph_size += instruction_size;
@@ -601,7 +602,8 @@ bool ReconstructGlyf(std::span<const uint8_t> data, Table* glyf_table,
 
       glyph_size = Store16(glyph_buf_view, glyph_size, n_contours);
       if (have_bbox) {
-        if (PREDICT_FALSE(!bbox_stream.Read(glyph_buf.get() + glyph_size, 8))) {
+        if (PREDICT_FALSE(
+                !bbox_stream.Read(glyph_buf_view.subspan(glyph_size), 8))) {
           return FONT_COMPRESSION_FAILURE();
         }
       } else {
@@ -618,8 +620,8 @@ bool ReconstructGlyf(std::span<const uint8_t> data, Table* glyf_table,
       }
 
       glyph_size = Store16(glyph_buf_view, glyph_size, instruction_size);
-      if (PREDICT_FALSE(!instruction_stream.Read(glyph_buf.get() + glyph_size,
-                                                 instruction_size))) {
+      if (PREDICT_FALSE(!instruction_stream.Read(
+              glyph_buf_view.subspan(glyph_size), instruction_size))) {
         return FONT_COMPRESSION_FAILURE();
       }
       glyph_size += instruction_size;

--- a/src/woff2_dec.cc
+++ b/src/woff2_dec.cc
@@ -863,8 +863,8 @@ bool ReadTableDirectory(Buffer* file, std::vector<Table>* tables,
 }
 
 // Writes a single Offset Table entry
-size_t StoreOffsetTable(uint8_t* result, size_t offset, uint32_t flavor,
-                        uint16_t num_tables) {
+size_t StoreOffsetTable(std::span<uint8_t> result, size_t offset,
+                        uint32_t flavor, uint16_t num_tables) {
   offset = StoreU32(result, offset, flavor);  // sfnt version
   offset = Store16(result, offset, num_tables);  // num_tables
   unsigned max_pow2 = 0;
@@ -879,7 +879,8 @@ size_t StoreOffsetTable(uint8_t* result, size_t offset, uint32_t flavor,
   return offset;
 }
 
-size_t StoreTableEntry(uint8_t* result, uint32_t offset, uint32_t tag) {
+size_t StoreTableEntry(std::span<uint8_t> result, uint32_t offset,
+                       uint32_t tag) {
   offset = StoreU32(result, offset, tag);
   offset = StoreU32(result, offset, 0);
   offset = StoreU32(result, offset, 0);
@@ -1277,7 +1278,7 @@ bool WriteHeaders(RebuildMetadata* metadata, WOFF2Header* hdr, WOFF2Out* out) {
   }
 
   // Start building the font
-  uint8_t* result = &output[0];
+  std::span<uint8_t> result(output);
   size_t offset = 0;
   if (hdr->header_version) {
     // TTC header


### PR DESCRIPTION
This PR uses std::span for all the raw pointers that can reasonably be rewritten (found with -Wunsafe-buffer-usage). When built with libc++ hardening this will crash on all out-of-bounds accesses instead of causing undefined behavior. This is mostly only done for woff2 decompression.

This bumps the required C++ version from 11 to 20 to get std::span, but alternatively I could pull in a span implementation from somewhere else (e.g. Chromium).

This also adds a simple correctness "fuzzer" which takes input and then compresses/decompresses/re-compresses it, and checks the two compressed versions are equivalent.