### PR TITLE
update install setup using static linkage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ By default, shared libraries are built. To use static linkage, do:
 ```
 cd woff2
 mkdir out-static
+cd out-static
 cmake -DBUILD_SHARED_LIBS=OFF ..
 make
 make install


### PR DESCRIPTION
the install commands for static linkage was missing the `cd` command to switch directory