### PR TITLE
Fix integer wraparound in Buffer bounds checks on 32-bit platforms

### DIFF
--- a/src/buffer.h
+++ b/src/buffer.h
@@ -82,7 +82,7 @@ class Buffer {
   }
 
   inline bool ReadU8(uint8_t *value) {
-    if (offset_ + 1 > length_) {
+    if (length_ < 1 || offset_ > length_ - 1) {
       return FONT_COMPRESSION_FAILURE();
     }
     *value = buffer_[offset_];
@@ -91,7 +91,7 @@ class Buffer {
   }
 
   bool ReadU16(uint16_t *value) {
-    if (offset_ + 2 > length_) {
+    if (length_ < 2 || offset_ > length_ - 2) {
       return FONT_COMPRESSION_FAILURE();
     }
     std::memcpy(value, buffer_ + offset_, sizeof(uint16_t));
@@ -105,7 +105,7 @@ class Buffer {
   }
 
   bool ReadU24(uint32_t *value) {
-    if (offset_ + 3 > length_) {
+    if (length_ < 3 || offset_ > length_ - 3) {
       return FONT_COMPRESSION_FAILURE();
     }
     *value = static_cast<uint32_t>(buffer_[offset_]) << 16 |
@@ -116,7 +116,7 @@ class Buffer {
   }
 
   bool ReadU32(uint32_t *value) {
-    if (offset_ + 4 > length_) {
+    if (length_ < 4 || offset_ > length_ - 4) {
       return FONT_COMPRESSION_FAILURE();
     }
     std::memcpy(value, buffer_ + offset_, sizeof(uint32_t));
@@ -130,7 +130,7 @@ class Buffer {
   }
 
   bool ReadTag(uint32_t *value) {
-    if (offset_ + 4 > length_) {
+    if (length_ < 4 || offset_ > length_ - 4) {
       return FONT_COMPRESSION_FAILURE();
     }
     std::memcpy(value, buffer_ + offset_, sizeof(uint32_t));
@@ -139,7 +139,7 @@ class Buffer {
   }
 
   bool ReadR64(uint64_t *value) {
-    if (offset_ + 8 > length_) {
+    if (length_ < 8 || offset_ > length_ - 8) {
       return FONT_COMPRESSION_FAILURE();
     }
     std::memcpy(value, buffer_ + offset_, sizeof(uint64_t));
@@ -151,7 +151,13 @@ class Buffer {
   size_t offset() const { return offset_; }
   size_t length() const { return length_; }
 
-  void set_offset(size_t newoffset) { offset_ = newoffset; }
+  bool set_offset(size_t newoffset) {
+    if (newoffset > length_) {
+      return FONT_COMPRESSION_FAILURE();
+    }
+    offset_ = newoffset;
+    return true;
+  }
 
  private:
   const uint8_t * const buffer_;

--- a/src/font.cc
+++ b/src/font.cc
@@ -155,7 +155,9 @@ bool ReadTrueTypeCollection(Buffer* file, const uint8_t* data, size_t len,
 
     std::map<uint32_t, Font::Table*> all_tables;
     for (const auto offset : offsets) {
-      file->set_offset(offset);
+      if (!file->set_offset(offset)) {
+        return FONT_COMPRESSION_FAILURE();
+      }
       Font& font = *font_it++;
       if (!ReadCollectionFont(file, data, len, &font, &all_tables)) {
         return FONT_COMPRESSION_FAILURE();


### PR DESCRIPTION
## Summary

The typed Read methods in `Buffer` (`ReadU8`, `ReadU16`, `ReadU24`, `ReadU32`, `ReadTag`, `ReadR64`) use bounds checks of the form `offset_ + N > length_`. On 32-bit platforms where `size_t` is 32 bits, if `offset_` is close to `SIZE_MAX` (e.g. `0xFFFFFFFF`), the addition `offset_ + N` wraps around to a small value, bypassing the bounds check and allowing out-of-bounds reads from the underlying buffer.

**Root cause:** unsigned integer wraparound in `offset_ + N` when `offset_` is near `SIZE_MAX` on ILP32 platforms.

**Fix:** Restructure all bounds checks from `offset_ + N > length_` to `length_ < N || offset_ > length_ - N`, which avoids any arithmetic that could overflow. This pattern is consistent with the existing `Read(uint8_t*, size_t)` method which already uses the safe `offset_ > length_ - n_bytes` form.

Additionally, `set_offset()` previously accepted any value without validation. This is changed to return `bool` and reject offsets beyond the buffer length. The sole caller in `font.cc` (TTC collection font parsing) now checks the return value.

## Changes

- `src/buffer.h`: Fix bounds checks in `ReadU8`, `ReadU16`, `ReadU24`, `ReadU32`, `ReadTag`, `ReadR64` to use overflow-safe comparisons
- `src/buffer.h`: Change `set_offset()` from `void` to `bool` with bounds validation
- `src/font.cc`: Check `set_offset()` return value when seeking to TTC font offsets

## Impact

An attacker supplying a crafted WOFF2 font could potentially trigger out-of-bounds memory reads on 32-bit platforms (e.g., 32-bit Android, embedded systems, wasm32) by manipulating the buffer offset to near `SIZE_MAX`. This could lead to information disclosure or crashes.

## Test plan

- Verified the project builds cleanly with `make`
- The fix is a minimal, mechanical change to comparison operand ordering
- No functional change on 64-bit platforms (the wraparound is not practically reachable with 64-bit `size_t`)