### PR TITLE
fix integer wraparound in StorePoints bounds check on 32-bit

### DIFF
--- a/src/glyph.cc
+++ b/src/glyph.cc
@@ -305,7 +305,10 @@ bool StorePoints(const Glyph& glyph, size_t* offset,
     dst[(*offset)++] = repeat_count;
   }
 
-  if (*offset + x_bytes + y_bytes > dst_size) {
+  size_t xy_bytes = x_bytes + y_bytes;
+  if (xy_bytes < x_bytes ||
+      dst_size < xy_bytes ||
+      *offset > dst_size - xy_bytes) {
     return FONT_COMPRESSION_FAILURE();
   }
 


### PR DESCRIPTION
StorePoints in glyph.cc guards the coordinate writes with `*offset + x_bytes + y_bytes > dst_size`. On 32-bit platforms that sum wraps and can slip past the check, letting the following coordinate stores run past dst. The decoder's StorePoints already guards this; restructure to the same non-wrapping form used in the recent Buffer bounds-check fix.