### PR TITLE
Notify the user in text if woff2_decompress has failed

### DIFF
--- a/src/woff2_decompress.cc
+++ b/src/woff2_decompress.cc
@@ -36,6 +36,8 @@ int main(int argc, char **argv) {
   if (ok) {
     woff2::SetFileContents(outfilename, output.begin(),
         output.begin() + out.Size());
+  } else {
+     fprintf(stderr, "Decompresison failed\n");
   }
   return ok ? 0 : 1;
 }


### PR DESCRIPTION
`woff2_decompress` does not notify the user if it has failed, this can be confusing to work with if font data is invalid