### PR TITLE
Add Windows ARM64 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # several CI services, such as Travis and Drone, use it.  Solaris 11
 # has 2.8.6, and it's not difficult to support if you already have to
 # support 2.8.7.
-cmake_minimum_required(VERSION 2.8.6)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(woff2)
 
@@ -43,24 +43,29 @@ if (NOT BROTLIENC_FOUND)
 endif ()
 
 # Set compiler flags
-if (NOT CANONICAL_PREFIXES)
-    add_definitions(-no-canonical-prefixes)
-  endif ()
 if (NOISY_LOGGING)
     add_definitions(-DFONT_COMPRESSION_BIN)
 endif ()
 add_definitions(-D__STDC_FORMAT_MACROS)
-set(COMMON_FLAGS -fno-omit-frame-pointer)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    add_definitions(-DOS_MACOSX)
+if (MSVC)
+    # MSVC-specific flags
+    set(COMMON_FLAGS "/W3")
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 else ()
-    set(COMMON_FLAGS "${COMMON_FLAG} -fno-omit-frame-pointer")
-endif()
+    # GCC/Clang-specific flags
+    if (NOT CANONICAL_PREFIXES)
+        set(COMMON_FLAGS "-no-canonical-prefixes")
+    endif ()
+    set(COMMON_FLAGS "${COMMON_FLAGS} -fno-omit-frame-pointer")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_FLAG}")
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        add_definitions(-DOS_MACOSX)
+    endif()
+endif ()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_FLAG}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_FLAGS}")
 set(CMAKE_CXX_STANDARD 11)
 
 # Set search path for our private/public headers as well as Brotli headers

--- a/src/port.h
+++ b/src/port.h
@@ -11,6 +11,10 @@
 
 #include <assert.h>
 
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
 namespace woff2 {
 
 typedef unsigned int       uint32;
@@ -18,6 +22,12 @@ typedef unsigned int       uint32;
 inline int Log2Floor(uint32 n) {
 #if defined(__GNUC__)
   return n == 0 ? -1 : 31 ^ __builtin_clz(n);
+#elif defined(_MSC_VER)
+  unsigned long result;
+  if (n == 0)
+    return -1;
+  _BitScanReverse(&result, n);
+  return result;
 #else
   if (n == 0)
     return -1;
@@ -54,9 +64,14 @@ inline int Log2Floor(uint32 n) {
 
 #if (defined(__ARM_ARCH) && (__ARM_ARCH == 7)) || \
     (defined(M_ARM) && (M_ARM == 7)) || \
-    defined(__aarch64__) || defined(__ARM64_ARCH_8__) || defined(__i386) || \
+    defined(__aarch64__) || defined(__ARM64_ARCH_8__) || \
+    defined(_M_ARM64) || \
+    defined(__i386) || \
     defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
-#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#if defined(_WIN32)
+/* Windows is always little-endian on all supported architectures */
+#define WOFF_LITTLE_ENDIAN
+#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 #define WOFF_LITTLE_ENDIAN
 #elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 #define WOFF_BIG_ENDIAN


### PR DESCRIPTION
Add Windows ARM64 (MSVC) build support

- src/port.h: Add _M_ARM64 to CPU architecture whitelist for endianness
  detection. Add _WIN32 fallback for little-endian since MSVC does not
  define __BYTE_ORDER__. Add MSVC-optimized Log2Floor using
  _BitScanReverse intrinsic.

- CMakeLists.txt: Gate GCC/Clang-specific compiler flags behind if(MSVC)
  check. Add MSVC flags (/W3, _CRT_SECURE_NO_WARNINGS). Update
  cmake_minimum_required to VERSION 3.5.0. Fix COMMON_FLAGS variable
  name typo.
